### PR TITLE
Structural Issue: The console consumes * characters, preventing simple math functions

### DIFF
--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -75,7 +75,7 @@ void SerialConsole::on_serial_char_received() {
 			query_flag = true;
 			continue;
 		}
-		if (received == '*') {
+		if (received == '&') {
 			diagnose_flag = true;
 			continue;
 		}

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -129,7 +129,7 @@ void WifiProvider::receive_wifi_data() {
 	            query_flag = true;
 	            continue;
 	        }
-			if (WifiData[i] == '*') {
+			if (WifiData[i] == '&') {
 				diagnose_flag = true;
 				continue;
 			}


### PR DESCRIPTION
The * character is used for diagnostic queries between the machine and the controller. It is not used by smoothieware and is a makera addition.

When a * is sent through the console to the machine, the machine immediately sends the diagnostic string back and removes it from the serial queue. This means it never reaches the gcode interpreter. 

By consuming * characters, the firmware prevents us from implementing multiplication as 1*1 returns 2 in gcode, but 11 in the console. (in our dev branch),

If the character were changed to '&' instead, there would be no conflicts.

This would also require a change to controller.py 
line 718  self.stream.send(b"*") -> self.stream.send(b"&") 
and 397 change the * to &