### PR TITLE
adding a clarification message to feed rate <= 0 errors

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1640,6 +1640,7 @@ bool Robot::append_line(Gcode *gcode, const float target[], float rate_mm_s, flo
     if(rate_mm_s <= 0.0F) {
         gcode->is_error= true;
         gcode->txt_after_ok= (rate_mm_s == 0 ? "Undefined feed rate" : "feed rate < 0");
+        THEKERNEL->streams->printf(rate_mm_s == 0 ? "Undefined feed rate" : "feed rate < 0");
         return false;
     }
 


### PR DESCRIPTION
The machine expects feed rates that are greater than zero, but only prints the error to the USB message buffer, leading to potential user confusion due to an undocumented machine halt This adds a print statement to inform the user of why the halt is occurring

Halting on invalid feed rates is the industry standard behavior and occurs in LinuxCNC, Mach3 and others

this pull request is in relation to https://discord.com/channels/910194756473225269/910194757198835804/1307991131518140468