### PR TITLE
clarify ATC tool detection failure messages

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1142,14 +1142,14 @@ void ATCHandler::on_gcode_received(void *argument)
 					if (!laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
 				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
 					}
 				} else if (gcode->subcode == 2) {
 					// check false
 					if (laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);
 				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ERROR: Unexpected tool presence detected, please check tool rack!\n");
 					}
 				} else if (gcode->subcode == 3) {
 					// check if the probe was triggered


### PR DESCRIPTION
Current behavior: if the atc tool change operation laser detects a tool in the atc when there shouldn't be, or doesn't detect a tool when there should be it prints the same message to the console. 

This change modifies the text of those print statements to clarify which situation is occurring to help the end user troubleshoot the problem. 
