### PR TITLE
Bugfix: preventing TLO calibration if machine has not been homed

### DIFF
--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -101,6 +101,8 @@ class Robot : public Module {
             uint8_t plane_axis_2:2;
         };
 
+        bool is_homed(uint8_t i) const;
+
     private:
         enum MOTION_MODE_T {
             NONE,
@@ -116,7 +118,7 @@ class Robot : public Module {
         bool append_arc( Gcode* gcode, const float target[], const float offset[], float radius, bool is_clockwise );
         bool compute_arc(Gcode* gcode, const float offset[], const float target[], enum MOTION_MODE_T motion_mode);
         void process_move(Gcode *gcode, enum MOTION_MODE_T);
-        bool is_homed(uint8_t i) const;
+        
 
         float theta(float x, float y);
         void select_plane(uint8_t axis_0, uint8_t axis_1, uint8_t axis_2);

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -141,6 +141,14 @@ void ATCHandler::fill_change_scripts(int new_tool, bool clear_z) {
 
 void ATCHandler::fill_drop_scripts(int old_tool) {
 	char buff[100];
+	for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+		if (!THEROBOT->is_homed(i)){
+			THEKERNEL->set_halt_reason(HOME_FAIL);
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->streams->printf("Machine has not been homed\n");
+			return;
+		}
+	}
 	struct atc_tool *current_tool = &atc_tools[old_tool];
 	// set atc status
 	this->script_queue.push("M497.1");
@@ -174,6 +182,14 @@ void ATCHandler::fill_drop_scripts(int old_tool) {
 
 void ATCHandler::fill_pick_scripts(int new_tool, bool clear_z) {
 	char buff[100];
+	for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+		if (!THEROBOT->is_homed(i)){
+			THEKERNEL->set_halt_reason(HOME_FAIL);
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->streams->printf("Machine has not been homed\n");
+			return;
+		}
+	}
 	struct atc_tool *current_tool = &atc_tools[new_tool];
 	// set atc status
 	this->script_queue.push("M497.2");
@@ -211,7 +227,15 @@ void ATCHandler::fill_pick_scripts(int new_tool, bool clear_z) {
 
 void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z) {
 	char buff[100];
-	
+	for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+		if (!THEROBOT->is_homed(i)){
+			THEKERNEL->set_halt_reason(HOME_FAIL);
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->streams->printf("Machine has not been homed\n");
+			return;
+		}
+	}
+
 	if(is_probe){
 	// open probe laser
 		this->script_queue.push("M494.1");
@@ -373,7 +397,14 @@ void ATCHandler::fill_zprobe_scripts(float x_pos, float y_pos, float x_offset, f
 
 void ATCHandler::fill_zprobe_abs_scripts() {
 	char buff[100];
-
+	for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+		if (!THEROBOT->is_homed(i)){
+			THEKERNEL->set_halt_reason(HOME_FAIL);
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->streams->printf("Machine has not been homed\n");
+			return;
+		}
+	}
 	// set atc status
 	this->script_queue.push("M497.5");	
 	
@@ -504,7 +535,14 @@ void ATCHandler::fill_autolevel_scripts(float x_pos, float y_pos,
 		float x_size, float y_size, int x_grids, int y_grids, float height)
 {
 	char buff[100];
-
+	for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+		if (!THEROBOT->is_homed(i)){
+			THEKERNEL->set_halt_reason(HOME_FAIL);
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->streams->printf("Machine has not been homed\n");
+			return;
+		}
+	}
 	// set atc status
 	this->script_queue.push("M497.6");
 	


### PR DESCRIPTION
There was a rare bug that could damage the ATC if the machine was not homed due to a home fail or the estop being pressed on machine start.

I made THEROBOT->is_homed(axis) public and added tests to each of the atc functions to make sure the atc is homed before the machine starts that process. 