### PR TITLE
Added an is homed check to the machine to prevent crashes

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -2076,3 +2076,24 @@ bool Robot::is_homed(uint8_t i) const
     if(!ok) return false;
     return homed[i];
 }
+
+bool Robot::is_homed_all_axes()
+{
+    if (this->home_override){
+        return true;
+    }
+    for (int i = X_AXIS; i <= Z_AXIS; ++i) {
+        if (!this->is_homed(i)){
+            THEKERNEL->streams->printf("Machine has not been homed\nUse M888 To disable homed check temporarily\n");
+            THEKERNEL->set_halt_reason(HOME_FAIL);
+            THEKERNEL->call_event(ON_HALT, nullptr);
+            return false;
+        }
+    }
+    return true;
+}
+
+void Robot::override_homed_check(bool home_override_value) {
+    this->home_override = home_override_value;
+    return;
+}

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -67,6 +67,9 @@ class Robot : public Module {
         uint8_t get_current_motion_mode() const {return current_motion_mode; }
         void clearLaserOffset();
 
+        bool is_homed_all_axes();
+        void override_homed_check(bool home_override_value);
+
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 
         // gets accessed by Panel, Endstops, ZProbe
@@ -102,6 +105,7 @@ class Robot : public Module {
         };
 
     private:
+        bool home_override = false;
         enum MOTION_MODE_T {
             NONE,
             SEEK, // G0

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -148,6 +148,11 @@ void ATCHandler::fill_change_scripts(int new_tool, bool clear_z) {
 
 void ATCHandler::fill_drop_scripts(int old_tool) {
 	char buff[100];
+
+	if (!THEROBOT->is_homed_all_axes()) {
+		return;
+	};
+	
 	struct atc_tool *current_tool = &atc_tools[old_tool];
 	// set atc status
 	this->script_queue.push("M497.1");
@@ -181,6 +186,9 @@ void ATCHandler::fill_drop_scripts(int old_tool) {
 
 void ATCHandler::fill_pick_scripts(int new_tool, bool clear_z) {
 	char buff[100];
+	if (!THEROBOT->is_homed_all_axes()) {
+		return;
+	};
 	struct atc_tool *current_tool = &atc_tools[new_tool];
 	// set atc status
 	this->script_queue.push("M497.2");
@@ -218,7 +226,10 @@ void ATCHandler::fill_pick_scripts(int new_tool, bool clear_z) {
 
 void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z) {
 	char buff[100];
-	
+	if (!THEROBOT->is_homed_all_axes()) {
+		return;
+	};
+
 	if(is_probe){
 	// open probe laser
 		this->script_queue.push("M494.1");
@@ -380,7 +391,9 @@ void ATCHandler::fill_zprobe_scripts(float x_pos, float y_pos, float x_offset, f
 
 void ATCHandler::fill_zprobe_abs_scripts() {
 	char buff[100];
-
+	if (!THEROBOT->is_homed_all_axes()) {
+		return;
+	};
 	// set atc status
 	this->script_queue.push("M497.5");	
 	
@@ -511,7 +524,9 @@ void ATCHandler::fill_autolevel_scripts(float x_pos, float y_pos,
 		float x_size, float y_size, int x_grids, int y_grids, float height)
 {
 	char buff[100];
-
+	if (!THEROBOT->is_homed_all_axes()) {
+		return;
+	};
 	// set atc status
 	this->script_queue.push("M497.6");
 	
@@ -1252,6 +1267,12 @@ void ATCHandler::on_gcode_received(void *argument)
 
 			}
 		} else if (gcode->m == 495) {
+			if (!THEROBOT->is_homed_all_axes()) {
+				this->atc_status = NONE;
+        		this->clear_script_queue();
+        		this->set_inner_playing(false);
+				return;
+			};
 			if (gcode->subcode == 3) {
 				float tool_dia = 3.175;
 				float probe_height = 9.0;
@@ -1458,7 +1479,14 @@ void ATCHandler::on_gcode_received(void *argument)
 				this->beep_tool_change(tool_to_change);
 
 			}
+		} else if ( gcode->m == 887 ) {
+			THEROBOT->override_homed_check(false);
+			THEKERNEL->streams->printf("Home Check Disabled\n");
+		} else if ( gcode->m == 888 ) {
+			THEROBOT->override_homed_check(true);
+			THEKERNEL->streams->printf("Home Check Enabled\n");
 		}
+
     } else if (gcode->has_g && gcode->g == 28 && gcode->subcode == 0) {
     	g28_triggered = true;
     }

--- a/version.txt
+++ b/version.txt
@@ -1,6 +1,30 @@
 Notice: 
 To let the Carvera work perfectly, please make sure both your controller software and firmware are up to date. For firmware, download the new firmware first, then use the 'update' function to upgrade the firmware, and reset the machine after the update is complete.
 
+[1.0.2]
+1. Carvera Support  the new 4th Axis Module (Harmonic Drive Version).
+2. Bug fixing: Fix the command to query the MAC address of the machine.
+3. Optimizing: Improve the stability of file transfer and reduce the problem of machine movement when uploading files abnormally.
+4. Optimizing:Change external output to hardware PWM mode.
+5. Optimizing:The command to query diagnostic information has been changed from the character '*' to 'diagnose'
+6. Bug fixing: Fix the issue of incorrect 4-axis rotation angle in Inch mode
+
+**NOTE: To ensure the compatibility of firmware and controller, it is recommended to upgrade both firmware and Controller.**
+
+[1.0.1]
+1. Bug fixing:The issue of the machine not responding to Controller commands or main buttons after the motor alarm
+2. Bug fixing: if the atc tool change operation laser detects a tool in the atc when there shouldn't be, or doesn't detect a tool when there should be it prints the same message to the MDI.
+3. Optimizing: Add data feedback on tabletop exploration ： 'Max deviation between high and low'
+4. Optimizing:when the feed rates in Gcode are not greater than zero, then will print Alarm info to the MDI
+5. Optimizing: Add motor alarm detection during machin
+
+[1.0.0]
+1. Optimizing: Add data feedback on tabletop exploration ： 'Max deviation between high and low'
+2. Optimizing: Add motor alarm detection during machine home operation
+
+[0.9.9]
+Firmware compatible with Carvera and Carvera Air
+
 [0.9.8]
 1. Optimizing: Improve file transfer speed
 2. Optimizing:  wifi Library file upgrade


### PR DESCRIPTION
The is homed check is run before atc commands and play file commands and will stop the machine from crashing should the user fail to home the machine due to accidentally leaving the estop down when the machine starts. 

This behavior can be overridden with M887 and M888 (check off and on respectively) and gives a home failed error as well as extra information in the MDI.

