### PR TITLE
Fix Player.cpp to use metric, then switch back to previously set unit

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -931,12 +931,20 @@ void Player::resume_command(string parameters, StreamOutput *stream )
         THEROBOT->absolute_mode = true;
 
         char buf[128];
-        snprintf(buf, sizeof(buf), "G1 X%.3f Y%.3f Z%.3f F%.3f", saved_position[0], saved_position[1], saved_position[2], THEROBOT->from_millimeters(1000));
+        char buf2[128];
+        snprintf(buf, sizeof(buf), "G21 G1 X%.3f Y%.3f Z%.3f F%.3f", saved_position[0], saved_position[1], saved_position[2], THEROBOT->from_millimeters(1000));
+        snprintf(buf2, sizeof(buf), "G%i", THEROBOT->inch_mode ? 20 : 21);
+        stream->printf("G%i\n",THEROBOT->inch_mode ? 20 : 21);
         struct SerialMessage message;
         message.message = buf;
         message.stream = &(StreamOutput::NullStream);
         message.line = 0;
         THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
+        // fixed ur bug 3863 Pantherbotics -- Rohan & Alex
+        message.message= buf2;
+        message.line = 0;
+        THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+
 
     	if (current_motion_mode > 1) {
             snprintf(buf, sizeof(buf), "G%d", current_motion_mode - 1);


### PR DESCRIPTION
There was an issue where M600 would cause a soft limit error when run in G20. The machine would save the position of the spindle in millimeters regardless of G20 or G21. Then, when the user resumes the program, it would attempt to return to the saved position but would execute the Gcode command in whatever state the machine was in when it paused. This would cause a soft limit error in almost all cases. If the spindle was close enough to the WCS zero it would work but it would move to those coordinates in inches, which could cause a crash as Z could move down. We added a G21 to the line that executes the return to save position and had the machine return to the original unit system afterwards via another snprintf line. We have tested this in both G20 and G21 and it functions as normal, just minus the soft limit error.