### PR TITLE
Fix Player::goto_command to position to the target line instead of +1

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -431,7 +431,13 @@ void Player::goto_command( string parameters, StreamOutput *stream )
         played_lines = 0;
         played_cnt   = 0;
 
-        while (fgets(buf, sizeof(buf), this->current_file_handler) != NULL) {
+        // Read lines until we've positioned at the target line
+        // We want to break BEFORE reading the target line, so the file pointer is at the target
+        while (played_lines < this->goto_line - 1) {
+            if (fgets(buf, sizeof(buf), this->current_file_handler) == NULL) {
+                break; // EOF reached
+            }
+
         	if (played_lines % 100 == 0) {
                 THEKERNEL->call_event(ON_IDLE);
         	}
@@ -440,9 +446,6 @@ void Player::goto_command( string parameters, StreamOutput *stream )
 
             played_lines += 1;
             played_cnt += len;
-            if (played_lines >= this->goto_line) {
-            	break;
-            }
         }
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -1,6 +1,25 @@
 Notice: 
 To let the Carvera work perfectly, please make sure both your controller software and firmware are up to date. For firmware, download the new firmware first, then use the 'update' function to upgrade the firmware, and reset the machine after the update is complete.
 
+[1.0.5]
+Important Notes
+The firmware version v1.0.5 requires v0.9.13 Controller or higher.
+​​Please follow these steps:​​
+
+1.Use the v0.9.11 Controller to upgrade the firmware to v1.0.5.
+2.Then update the Controller to v0.9.13.
+(Note: This ensures compatibility between the Controller and firmware versions.)
+
+Overview of this upgrade
+1.​​Bug Fix​​: Fixed an issue where a line in G-code containing a line number (N) but no G-command would be ignored.
+2.​​Bug Fix​​: Resolved an issue where the hotspot subnet might overlap with the router subnet.
+3.​​Bug Fix​​: Corrected the Shrink Acommand, changing it from compressing machine coordinates to compressing work coordinates.
+4.​​Optimization​​: Improved firmware-Controller communication for more reliable file transfers.
+5.​​Optimization​​: Paused the lid detection alarm function during tool changes on the ​​Carvera Air​​.
+6.​​Optimization​​: Optimized the path movement to the work origin before machining to prevent collisions with the workpiece or fixture.
+7.​​Optimization​​: Updated the Wi-Fi driver.
+8.Optimization:Add conrner positioning and center positioning functions for the 3D probe.
+
 [1.0.4]
 1.​​Bug Fix​​: Fixed an issue where a line in G-code containing a line number (N) but no G-command would be ignored.
 2.​​Bug Fix​​: Resolved an issue where the hotspot subnet might overlap with the router subnet.


### PR DESCRIPTION
As discussed in https://github.com/Carvera-Community/Carvera_Community_Firmware/issues/216 the `goto` command currently progresses the file pointer to +1 of the target line. This PR re-orders the line checking before the `fgets()` so that `goto` works as described in the  [releases note description](https://github.com/Carvera-Community/Carvera_Community_Firmware/blob/c5b392035e04bfcb1a83adbb0a2734594367154a/version.txt#L207) and moves to the specified line number.